### PR TITLE
Validate access tokens and add endpoints for player statistic where player id is read from cookie

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,6 +67,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_URL=postgresql://overworld-db:5432/postgres
+      - KEYCLOAK_ISSUER=http://localhost/keycloak/realms/Gamify-IT
+      - KEYCLOAK_URL=http://keycloak/keycloak/realms/Gamify-IT
 
   # --- frontends ---
   landing-page:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<plugin.prettier.goal>write</plugin.prettier.goal>
 		<spring-cloud.version>2021.0.3</spring-cloud.version>
 		<testcontainer.version>1.17.3</testcontainer.version>
-		<de.uni-stuttgart.gamify-it.authentification-validator>v1.0.0</de.uni-stuttgart.gamify-it.authentification-validator>
+		<de.uni-stuttgart.gamify-it.authentification-validator.version>v1.0.0</de.uni-stuttgart.gamify-it.authentification-validator.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>de.uni-stuttgart.gamify-it</groupId>
 			<artifactId>authentification-validator</artifactId>
-			<version>${de.uni-stuttgart.gamify-it.authentification-validator}</version>
+			<version>${de.uni-stuttgart.gamify-it.authentification-validator.version}</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,15 @@
 		<plugin.prettier.goal>write</plugin.prettier.goal>
 		<spring-cloud.version>2021.0.3</spring-cloud.version>
 		<testcontainer.version>1.17.3</testcontainer.version>
+		<de.uni-stuttgart.gamify-it.authentification-validator>v1.0.0</de.uni-stuttgart.gamify-it.authentification-validator>
 	</properties>
+	<repositories>
+		<repository>
+			<id>sqa-artifactory</id>
+			<name>SQA Artifactory-releases</name>
+			<url>https://rss-artifactory.ddnss.org/artifactory/libs-release</url>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -88,6 +96,11 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 			<version>2.7.3</version>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>de.uni-stuttgart.gamify-it</groupId>
+			<artifactId>authentification-validator</artifactId>
+			<version>${de.uni-stuttgart.gamify-it.authentification-validator}</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/BookController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/BookController.java
@@ -1,10 +1,12 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.BookDTO;
 import de.unistuttgart.overworldbackend.data.NPCDTO;
 import de.unistuttgart.overworldbackend.service.BookService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +18,9 @@ import org.springframework.web.bind.annotation.*;
 public class BookController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private BookService bookService;
 
   @Operation(summary = "Update a book by its index in a world")
@@ -24,8 +29,11 @@ public class BookController {
     @PathVariable int courseId,
     @PathVariable int worldIndex,
     @PathVariable int bookIndex,
-    @RequestBody BookDTO bookDTO
+    @RequestBody BookDTO bookDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug("update book {} of world {} of course {}", bookIndex, worldIndex, courseId);
     return bookService.updateBookFromWorld(courseId, worldIndex, bookIndex, bookDTO);
   }
@@ -37,8 +45,11 @@ public class BookController {
     @PathVariable int worldIndex,
     @PathVariable int dungeonIndex,
     @PathVariable int bookIndex,
-    @RequestBody BookDTO bookDTO
+    @RequestBody BookDTO bookDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug(
       "update book {} of dungeon {} from world {} of course {} with {}",
       bookIndex,

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/DungeonController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/DungeonController.java
@@ -1,10 +1,12 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.DungeonDTO;
 import de.unistuttgart.overworldbackend.data.mapper.DungeonMapper;
 import de.unistuttgart.overworldbackend.service.DungeonService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,9 @@ import org.springframework.web.bind.annotation.*;
 public class DungeonController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private DungeonService dungeonService;
 
   @Autowired
@@ -24,7 +29,12 @@ public class DungeonController {
 
   @Operation(summary = "Get all dungeons of a world")
   @GetMapping("")
-  public Set<DungeonDTO> getDungeons(@PathVariable int courseId, @PathVariable int worldIndex) {
+  public Set<DungeonDTO> getDungeons(
+    @PathVariable int courseId,
+    @PathVariable int worldIndex,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get dungeons of world {} of course {}", worldIndex, courseId);
     return dungeonService.getDungeonsFromWorld(courseId, worldIndex);
   }
@@ -34,8 +44,10 @@ public class DungeonController {
   public DungeonDTO getDungeon(
     @PathVariable int courseId,
     @PathVariable int worldIndex,
-    @PathVariable int dungeonIndex
+    @PathVariable int dungeonIndex,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get dungeon {} of world {} of course {}", dungeonIndex, worldIndex, courseId);
     return dungeonMapper.dungeonToDungeonDTO(
       dungeonService.getDungeonByIndexFromCourse(courseId, worldIndex, dungeonIndex)
@@ -48,8 +60,11 @@ public class DungeonController {
     @PathVariable int courseId,
     @PathVariable int worldIndex,
     @PathVariable int dungeonIndex,
-    @RequestBody DungeonDTO dungeonDTO
+    @RequestBody DungeonDTO dungeonDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug("update dungeon {} of world {} of course {} with {}", dungeonIndex, worldIndex, courseId, dungeonDTO);
     return dungeonService.updateDungeonFromCourse(courseId, worldIndex, dungeonIndex, dungeonDTO);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameInputController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameInputController.java
@@ -25,7 +25,10 @@ public class MinigameInputController {
 
   @Operation(summary = "Submit statistics from a minigame run")
   @PostMapping("/submit-game-pass")
-  public PlayerTaskStatisticDTO inputData(@Valid @RequestBody PlayerTaskStatisticData data, @CookieValue("access_token") final String accessToken) {
+  public PlayerTaskStatisticDTO inputData(
+    @Valid @RequestBody PlayerTaskStatisticData data,
+    @CookieValue("access_token") final String accessToken
+  ) {
     jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("submitted data from game run {}", data);
     return playerTaskStatisticService.submitData(data);

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameInputController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameInputController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.PlayerTaskStatisticDTO;
 import de.unistuttgart.overworldbackend.data.PlayerTaskStatisticData;
 import de.unistuttgart.overworldbackend.service.PlayerTaskStatisticService;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Submit statistic", description = "Submit statistics")
 @RestController
@@ -20,11 +18,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class MinigameInputController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   PlayerTaskStatisticService playerTaskStatisticService;
 
   @Operation(summary = "Submit statistics from a minigame run")
   @PostMapping("/submit-game-pass")
-  public PlayerTaskStatisticDTO inputData(@Valid @RequestBody PlayerTaskStatisticData data) {
+  public PlayerTaskStatisticDTO inputData(@Valid @RequestBody PlayerTaskStatisticData data, @CookieValue("access_token") final String accessToken) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("submitted data from game run {}", data);
     return playerTaskStatisticService.submitData(data);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameTaskController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/MinigameTaskController.java
@@ -1,9 +1,11 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.MinigameTaskDTO;
 import de.unistuttgart.overworldbackend.service.MinigameTaskService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +19,19 @@ import org.springframework.web.bind.annotation.*;
 public class MinigameTaskController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private MinigameTaskService minigameTaskService;
 
   @Operation(summary = "Get all task from a world")
   @GetMapping("/minigame-tasks")
-  public Set<MinigameTaskDTO> getMinigameTasksFromWorld(@PathVariable int courseId, @PathVariable int worldIndex) {
+  public Set<MinigameTaskDTO> getMinigameTasksFromWorld(
+    @PathVariable int courseId,
+    @PathVariable int worldIndex,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get tasks of world {} of course {}", worldIndex, courseId);
     return minigameTaskService.getMinigameTasksFromArea(courseId, worldIndex);
   }
@@ -31,8 +41,10 @@ public class MinigameTaskController {
   public Set<MinigameTaskDTO> getMinigameTasksFromDungeon(
     @PathVariable int courseId,
     @PathVariable int worldIndex,
-    @PathVariable int dungeonIndex
+    @PathVariable int dungeonIndex,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get tasks of dungeon {} from world {} of course {}", dungeonIndex, worldIndex, courseId);
     return minigameTaskService.getMinigameTasksFromArea(courseId, worldIndex, dungeonIndex);
   }
@@ -42,8 +54,10 @@ public class MinigameTaskController {
   public MinigameTaskDTO getMinigameTaskFromWorld(
     @PathVariable int courseId,
     @PathVariable int worldIndex,
-    @PathVariable int taskIndex
+    @PathVariable int taskIndex,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get task {} of world {} of course {}", taskIndex, worldIndex, courseId);
     return minigameTaskService.getMinigameTaskFromArea(courseId, worldIndex, Optional.empty(), taskIndex);
   }
@@ -54,8 +68,10 @@ public class MinigameTaskController {
     @PathVariable int courseId,
     @PathVariable int worldIndex,
     @PathVariable int dungoenIndex,
-    @PathVariable int taskIndex
+    @PathVariable int taskIndex,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get task {} of dungeon {} from world {} of course {}", taskIndex, dungoenIndex, worldIndex, courseId);
     return minigameTaskService.getMinigameTaskFromArea(courseId, worldIndex, Optional.of(dungoenIndex), taskIndex);
   }
@@ -66,8 +82,11 @@ public class MinigameTaskController {
     @PathVariable int courseId,
     @PathVariable int worldIndex,
     @PathVariable int taskIndex,
-    @RequestBody MinigameTaskDTO minigameTaskDTO
+    @RequestBody MinigameTaskDTO minigameTaskDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug("update task {} of world {} of course {} with {}", taskIndex, worldIndex, courseId, minigameTaskDTO);
     return minigameTaskService.updateMinigameTaskFromArea(
       courseId,
@@ -85,8 +104,11 @@ public class MinigameTaskController {
     @PathVariable int worldIndex,
     @PathVariable int dungeonIndex,
     @PathVariable int taskIndex,
-    @RequestBody MinigameTaskDTO minigameTaskDTO
+    @RequestBody MinigameTaskDTO minigameTaskDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug(
       "update task {} of dungeon {} from world {} of course {} with {}",
       taskIndex,

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/NPCController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/NPCController.java
@@ -1,9 +1,11 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.NPCDTO;
 import de.unistuttgart.overworldbackend.service.NPCService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,9 @@ import org.springframework.web.bind.annotation.*;
 public class NPCController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private NPCService npcService;
 
   @Operation(summary = "Update a NPC by its index in a world")
@@ -23,8 +28,11 @@ public class NPCController {
     @PathVariable int courseId,
     @PathVariable int worldIndex,
     @PathVariable int npcIndex,
-    @RequestBody NPCDTO npcDTO
+    @RequestBody NPCDTO npcDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug("update npc {} of world {} of course {}", npcIndex, worldIndex, courseId);
     return npcService.updateNPCFromWorld(courseId, worldIndex, npcIndex, npcDTO);
   }
@@ -36,8 +44,11 @@ public class NPCController {
     @PathVariable int worldIndex,
     @PathVariable int dungeonIndex,
     @PathVariable int npcIndex,
-    @RequestBody NPCDTO npcDTO
+    @RequestBody NPCDTO npcDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    jwtValidatorService.hasRolesOrThrow(accessToken, List.of("lecturer"));
     log.debug(
       "update npc {} of dungeon {} from world {} of course {} with {}",
       npcIndex,

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/NPCInputController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/NPCInputController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.PlayerNPCStatisticDTO;
 import de.unistuttgart.overworldbackend.data.PlayerNPCStatisticData;
 import de.unistuttgart.overworldbackend.service.PlayerNPCStatisticService;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Submit statistic", description = "Submit statistics")
 @RestController
@@ -20,12 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class NPCInputController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   PlayerNPCStatisticService playerNPCStatisticService;
 
   @Valid
   @Operation(summary = "Submit statistics for a NPC for a player")
   @PostMapping("/submit-npc-pass")
-  public PlayerNPCStatisticDTO inputData(@RequestBody PlayerNPCStatisticData data) {
+  public PlayerNPCStatisticDTO inputData(@RequestBody PlayerNPCStatisticData data, @CookieValue("access_token") final String accessToken) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("submitted data from npc pass {}", data);
     return playerNPCStatisticService.submitData(data);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/NPCInputController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/NPCInputController.java
@@ -26,7 +26,10 @@ public class NPCInputController {
   @Valid
   @Operation(summary = "Submit statistics for a NPC for a player")
   @PostMapping("/submit-npc-pass")
-  public PlayerNPCStatisticDTO inputData(@RequestBody PlayerNPCStatisticData data, @CookieValue("access_token") final String accessToken) {
+  public PlayerNPCStatisticDTO inputData(
+    @RequestBody PlayerNPCStatisticData data,
+    @CookieValue("access_token") final String accessToken
+  ) {
     jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("submitted data from npc pass {}", data);
     return playerNPCStatisticService.submitData(data);

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerNPCStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerNPCStatisticController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Player statistic", description = "Get NPC statistics for a player")
 @RestController
 @Slf4j
-@RequestMapping("/courses/{courseId}/playerstatistics/{playerId}/player-npc-statistics")
+@RequestMapping("/courses/{courseId}/playerstatistics")
 public class PlayerNPCStatisticController {
 
   @Autowired
@@ -24,7 +24,7 @@ public class PlayerNPCStatisticController {
   private PlayerNPCStatisticService playerNPCStatisticService;
 
   @Operation(summary = "Get all NPC statistics of a player")
-  @GetMapping("")
+  @GetMapping("/{playerId}/player-npc-statistics")
   public List<PlayerNPCStatisticDTO> getPlayerNPCStatistics(
     @PathVariable int courseId,
     @PathVariable String playerId,
@@ -36,7 +36,7 @@ public class PlayerNPCStatisticController {
   }
 
   @Operation(summary = "Get specific NPC statistic of a player")
-  @GetMapping("/{statisticId}")
+  @GetMapping("/{playerId}/player-npc-statistics/{statisticId}")
   public PlayerNPCStatisticDTO getPlayerNPCStatistic(
     @PathVariable int courseId,
     @PathVariable String playerId,
@@ -45,6 +45,31 @@ public class PlayerNPCStatisticController {
   ) {
     jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get statistic {}", statisticId);
+    return playerNPCStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
+  }
+
+  @Operation(summary = "Get all NPC statistics of own player, player id is read from cookie")
+  @GetMapping("/player-npc-statistics")
+  public List<PlayerNPCStatisticDTO> getOwnPlayerNPCStatistics(
+    @PathVariable int courseId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    String playerId = jwtValidatorService.extractUserId(accessToken);
+    log.debug("get statistics of player by cookie {} in the course {}", playerId, courseId);
+    return playerNPCStatisticService.getAllStatisticsOfPlayer(courseId, playerId);
+  }
+
+  @Operation(summary = "Get own NPC statistic, player id is read from cookie")
+  @GetMapping("/player-npc-statistics/{statisticId}")
+  public PlayerNPCStatisticDTO getOwnPlayerNPCStatistic(
+    @PathVariable int courseId,
+    @PathVariable UUID statisticId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    String playerId = jwtValidatorService.extractUserId(accessToken);
+    log.debug("get statistic by cookie {}", statisticId);
     return playerNPCStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
   }
 }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerNPCStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerNPCStatisticController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.PlayerNPCStatisticDTO;
 import de.unistuttgart.overworldbackend.service.PlayerNPCStatisticService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,10 +9,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Player statistic", description = "Get NPC statistics for a player")
 @RestController
@@ -20,11 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlayerNPCStatisticController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private PlayerNPCStatisticService playerNPCStatisticService;
 
   @Operation(summary = "Get all NPC statistics of a player")
   @GetMapping("")
-  public List<PlayerNPCStatisticDTO> getPlayerNPCStatistics(@PathVariable int courseId, @PathVariable String playerId) {
+  public List<PlayerNPCStatisticDTO> getPlayerNPCStatistics(
+    @PathVariable int courseId,
+    @PathVariable String playerId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get statistics of player {} in the course {}", playerId, courseId);
     return playerNPCStatisticService.getAllStatisticsOfPlayer(courseId, playerId);
   }
@@ -34,8 +40,10 @@ public class PlayerNPCStatisticController {
   public PlayerNPCStatisticDTO getPlayerNPCStatistic(
     @PathVariable int courseId,
     @PathVariable String playerId,
-    @PathVariable UUID statisticId
+    @PathVariable UUID statisticId,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get statistic {}", statisticId);
     return playerNPCStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerStatisticController.java
@@ -42,7 +42,21 @@ public class PlayerStatisticController {
     );
   }
 
-  @Operation(summary = "Create a playerStatistic in a course by playerId ")
+  @Operation(summary = "Get own playerStatistic in a course of a player and courseId, player id is read from cookie")
+  @GetMapping("")
+  public PlayerStatisticDTO getOwnPlayerstatistic(
+    @PathVariable int courseId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    String playerId = jwtValidatorService.extractUserId(accessToken);
+    log.debug("get statistics from player by cookie {} in course {}", playerId, courseId);
+    return playerStatisticMapper.playerStatisticToPlayerstatisticDTO(
+      playerStatisticService.getPlayerStatisticFromCourse(courseId, playerId)
+    );
+  }
+
+  @Operation(summary = "Create a playerStatistic in a course by playerId")
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping("")
   public PlayerStatisticDTO createPlayerstatistic(
@@ -55,7 +69,7 @@ public class PlayerStatisticController {
     return playerStatisticService.createPlayerStatisticInCourse(courseId, player);
   }
 
-  @Operation(summary = "Update a playerStatistic in a course by playerId ")
+  @Operation(summary = "Update a playerStatistic in a course by playerId")
   @PutMapping("/{playerId}")
   public PlayerStatisticDTO updatePlayerStatistic(
     @PathVariable int courseId,

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerStatisticController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.Player;
 import de.unistuttgart.overworldbackend.data.PlayerStatisticDTO;
 import de.unistuttgart.overworldbackend.data.mapper.PlayerStatisticMapper;
@@ -19,6 +20,9 @@ import org.springframework.web.bind.annotation.*;
 public class PlayerStatisticController {
 
   @Autowired
+  JWTValidatorService jwtValidatorService;
+
+  @Autowired
   private PlayerStatisticService playerStatisticService;
 
   @Autowired
@@ -26,7 +30,12 @@ public class PlayerStatisticController {
 
   @Operation(summary = "Get a playerStatistic from a player in a course by playerId and courseId")
   @GetMapping("/{playerId}")
-  public PlayerStatisticDTO getPlayerstatistic(@PathVariable int courseId, @PathVariable String playerId) {
+  public PlayerStatisticDTO getPlayerstatistic(
+    @PathVariable int courseId,
+    @PathVariable String playerId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get statistics from player {} in course {}", playerId, courseId);
     return playerStatisticMapper.playerStatisticToPlayerstatisticDTO(
       playerStatisticService.getPlayerStatisticFromCourse(courseId, playerId)
@@ -36,7 +45,12 @@ public class PlayerStatisticController {
   @Operation(summary = "Create a playerStatistic in a course by playerId ")
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping("")
-  public PlayerStatisticDTO createPlayerstatistic(@PathVariable int courseId, @Valid @RequestBody Player player) {
+  public PlayerStatisticDTO createPlayerstatistic(
+    @PathVariable int courseId,
+    @Valid @RequestBody Player player,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("create playerstatistic for userId {} in course {}", player, courseId);
     return playerStatisticService.createPlayerStatisticInCourse(courseId, player);
   }
@@ -46,8 +60,10 @@ public class PlayerStatisticController {
   public PlayerStatisticDTO updatePlayerStatistic(
     @PathVariable int courseId,
     @PathVariable String playerId,
-    @RequestBody PlayerStatisticDTO playerstatisticDTO
+    @RequestBody PlayerStatisticDTO playerstatisticDTO,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("update playerStatistic for userId {} in course {} with {}", playerId, courseId, playerstatisticDTO);
     return playerStatisticService.updatePlayerStatisticInCourse(courseId, playerId, playerstatisticDTO);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerTaskStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerTaskStatisticController.java
@@ -1,5 +1,6 @@
 package de.unistuttgart.overworldbackend.controller;
 
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.PlayerTaskStatisticDTO;
 import de.unistuttgart.overworldbackend.repositories.PlayerTaskStatisticRepository;
 import de.unistuttgart.overworldbackend.service.PlayerTaskStatisticService;
@@ -9,16 +10,16 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Player statistic", description = "Get minigame statistics for a player")
 @RestController
 @Slf4j
 @RequestMapping("/courses/{courseId}/playerstatistics/{playerId}/player-task-statistics")
 public class PlayerTaskStatisticController {
+
+  @Autowired
+  JWTValidatorService jwtValidatorService;
 
   @Autowired
   private PlayerTaskStatisticRepository playerTaskStatisticRepository;
@@ -30,8 +31,10 @@ public class PlayerTaskStatisticController {
   @GetMapping("")
   public List<PlayerTaskStatisticDTO> getPlayerTaskStatistics(
     @PathVariable int courseId,
-    @PathVariable String playerId
+    @PathVariable String playerId,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get Statistics of Player {} in the course {}", playerId, courseId);
     return playerTaskStatisticService.getAllStatisticsOfPlayer(courseId, playerId);
   }
@@ -41,8 +44,10 @@ public class PlayerTaskStatisticController {
   public PlayerTaskStatisticDTO getPlayerTaskStatistic(
     @PathVariable int courseId,
     @PathVariable String playerId,
-    @PathVariable UUID statisticId
+    @PathVariable UUID statisticId,
+    @CookieValue("access_token") final String accessToken
   ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
     log.debug("get statistic {}", statisticId);
     return playerTaskStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
   }

--- a/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerTaskStatisticController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/PlayerTaskStatisticController.java
@@ -15,20 +15,17 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Player statistic", description = "Get minigame statistics for a player")
 @RestController
 @Slf4j
-@RequestMapping("/courses/{courseId}/playerstatistics/{playerId}/player-task-statistics")
+@RequestMapping("/courses/{courseId}/playerstatistics")
 public class PlayerTaskStatisticController {
 
   @Autowired
   JWTValidatorService jwtValidatorService;
 
   @Autowired
-  private PlayerTaskStatisticRepository playerTaskStatisticRepository;
-
-  @Autowired
   private PlayerTaskStatisticService playerTaskStatisticService;
 
-  @Operation(summary = "Get all minigame Statistics of Player")
-  @GetMapping("")
+  @Operation(summary = "Get all minigame statistics of a player")
+  @GetMapping("/{playerId}/player-task-statistics")
   public List<PlayerTaskStatisticDTO> getPlayerTaskStatistics(
     @PathVariable int courseId,
     @PathVariable String playerId,
@@ -39,8 +36,8 @@ public class PlayerTaskStatisticController {
     return playerTaskStatisticService.getAllStatisticsOfPlayer(courseId, playerId);
   }
 
-  @Operation(summary = "Get Statistic of a Player by id")
-  @GetMapping("/{statisticId}")
+  @Operation(summary = "Get a minigame statistic of a player by minigame statistic id")
+  @GetMapping("/{playerId}/player-task-statistics/{statisticId}")
   public PlayerTaskStatisticDTO getPlayerTaskStatistic(
     @PathVariable int courseId,
     @PathVariable String playerId,
@@ -48,6 +45,31 @@ public class PlayerTaskStatisticController {
     @CookieValue("access_token") final String accessToken
   ) {
     jwtValidatorService.validateTokenOrThrow(accessToken);
+    log.debug("get statistic {}", statisticId);
+    return playerTaskStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
+  }
+
+  @Operation(summary = "Get all minigame statistics of a player, player id is read from cookie")
+  @GetMapping("/player-task-statistics")
+  public List<PlayerTaskStatisticDTO> getOwnPlayerTaskStatistics(
+    @PathVariable int courseId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    String playerId = jwtValidatorService.extractUserId(accessToken);
+    log.debug("get Statistics of Player {} in the course {}", playerId, courseId);
+    return playerTaskStatisticService.getAllStatisticsOfPlayer(courseId, playerId);
+  }
+
+  @Operation(summary = "Get minigame statistic of a player by minigame statistic id, player id is read from cookie")
+  @GetMapping("/player-task-statistics/{statisticId}")
+  public PlayerTaskStatisticDTO getOwnPlayerTaskStatistic(
+    @PathVariable int courseId,
+    @PathVariable UUID statisticId,
+    @CookieValue("access_token") final String accessToken
+  ) {
+    jwtValidatorService.validateTokenOrThrow(accessToken);
+    String playerId = jwtValidatorService.extractUserId(accessToken);
     log.debug("get statistic {}", statisticId);
     return playerTaskStatisticService.getStatisticOfPlayer(courseId, playerId, statisticId);
   }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,6 @@ chickenshock.url= http://localhost/minigames/chickenshock/api/v1
 finitequiz.url= http://localhost/minigames/finitequiz/api/v1
 crosswordpuzzle.url= http://localhost/minigames/crosswordpuzzle/api/v1
 bugfinder.url= http://localhost/minigames/bugfinder/api/v1
+
+keycloak.issuer=http://localhost/keycloak/realms/Gamify-IT
+keycloak.url=http://localhost/keycloak/realms/Gamify-IT

--- a/src/test/java/de/unistuttgart/overworldbackend/CloneTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/CloneTest.java
@@ -190,7 +190,7 @@ public class CloneTest {
     String access_token = jsonParser.parseMap(result).get("access_token").toString();
 
     final MvcResult resultGet = mvc
-      .perform(get(fullURL + "/1").contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/1").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 

--- a/src/test/java/de/unistuttgart/overworldbackend/MinigameInputControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/MinigameInputControllerTest.java
@@ -1,11 +1,14 @@
 package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.*;
 import de.unistuttgart.overworldbackend.data.enums.Minigame;
 import de.unistuttgart.overworldbackend.data.mapper.*;
@@ -14,12 +17,14 @@ import de.unistuttgart.overworldbackend.repositories.MinigameTaskRepository;
 import de.unistuttgart.overworldbackend.repositories.PlayerStatisticRepository;
 import de.unistuttgart.overworldbackend.repositories.PlayerTaskActionLogRepository;
 import java.util.*;
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -50,6 +55,11 @@ class MinigameInputControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -177,6 +187,9 @@ class MinigameInputControllerTest {
     fullURL = "/internal";
 
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
@@ -190,7 +203,9 @@ class MinigameInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerTaskStatisticData);
 
     final MvcResult result = mvc
-      .perform(post(fullURL + "/submit-game-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-game-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 
@@ -233,7 +248,9 @@ class MinigameInputControllerTest {
       final String bodyValue = objectMapper.writeValueAsString(playerTaskStatisticData);
 
       mvc
-        .perform(post(fullURL + "/submit-game-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+        .perform(
+          post(fullURL + "/submit-game-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+        )
         .andExpect(status().isOk());
     }
 
@@ -252,7 +269,9 @@ class MinigameInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerTaskStatisticData);
 
     mvc
-      .perform(post(fullURL + "/submit-game-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-game-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound());
   }
 
@@ -267,7 +286,9 @@ class MinigameInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerTaskStatisticData);
 
     mvc
-      .perform(post(fullURL + "/submit-game-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-game-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound());
   }
 
@@ -278,7 +299,7 @@ class MinigameInputControllerTest {
     final String bodyValueCourse = objectMapper.writeValueAsString(toCreateCourse);
 
     final MvcResult resultCourse = mvc
-      .perform(post(currentUrl).content(bodyValueCourse).contentType(MediaType.APPLICATION_JSON))
+      .perform(post(currentUrl).content(bodyValueCourse).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isCreated())
       .andReturn();
 
@@ -306,6 +327,7 @@ class MinigameInputControllerTest {
           "/minigame-tasks/" +
           updateMinigameTaskDTO.getIndex()
         )
+          .cookie(cookie)
           .content(bodyValueTask)
           .contentType(MediaType.APPLICATION_JSON)
       )
@@ -323,6 +345,7 @@ class MinigameInputControllerTest {
     final MvcResult resultStatistic = mvc
       .perform(
         post("/courses/" + createdCourse.getId() + "/playerstatistics")
+          .cookie(cookie)
           .content(bodyValue)
           .contentType(MediaType.APPLICATION_JSON)
       )
@@ -343,7 +366,12 @@ class MinigameInputControllerTest {
     final String bodyValueMinigame = objectMapper.writeValueAsString(playerTaskStatisticData);
 
     final MvcResult resultPlayerStatistic = mvc
-      .perform(post(fullURL + "/submit-game-pass").content(bodyValueMinigame).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-game-pass")
+          .cookie(cookie)
+          .content(bodyValueMinigame)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 

--- a/src/test/java/de/unistuttgart/overworldbackend/MinigameTaskControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/MinigameTaskControllerTest.java
@@ -1,11 +1,14 @@
 package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.*;
 import de.unistuttgart.overworldbackend.data.enums.Minigame;
 import de.unistuttgart.overworldbackend.data.mapper.DungeonMapper;
@@ -15,11 +18,13 @@ import de.unistuttgart.overworldbackend.repositories.CourseRepository;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.UUID;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -51,6 +56,11 @@ class MinigameTaskControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -170,12 +180,15 @@ class MinigameTaskControllerTest {
     fullURL = String.format("/courses/%d/worlds/%d", initialCourse.getId(), initialWorld.getIndex());
 
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
   void getMinigameTasksFromWorld() throws Exception {
     final MvcResult result = mvc
-      .perform(get(fullURL + "/minigame-tasks").contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/minigame-tasks").cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 
@@ -192,6 +205,7 @@ class MinigameTaskControllerTest {
     final MvcResult result = mvc
       .perform(
         get(fullURL + "/dungeons/" + initialDungeon.getIndex() + "/minigame-tasks")
+          .cookie(cookie)
           .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isOk())
@@ -208,7 +222,11 @@ class MinigameTaskControllerTest {
   @Test
   void getMinigameTaskFromWorld() throws Exception {
     final MvcResult result = mvc
-      .perform(get(fullURL + "/minigame-tasks/" + initialTask1.getIndex()).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        get(fullURL + "/minigame-tasks/" + initialTask1.getIndex())
+          .cookie(cookie)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 
@@ -223,7 +241,9 @@ class MinigameTaskControllerTest {
   @Test
   void getMinigameTaskFromWorld_DoesNotExist_ThrowsNotFound() throws Exception {
     mvc
-      .perform(get(fullURL + "/minigame-tasks/" + Integer.MAX_VALUE).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        get(fullURL + "/minigame-tasks/" + Integer.MAX_VALUE).cookie(cookie).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound())
       .andReturn();
   }
@@ -233,6 +253,7 @@ class MinigameTaskControllerTest {
     final MvcResult result = mvc
       .perform(
         get(fullURL + "/dungeons/" + initialDungeon.getIndex() + "/minigame-tasks/" + initialTask3.getIndex())
+          .cookie(cookie)
           .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isOk())
@@ -251,6 +272,7 @@ class MinigameTaskControllerTest {
     mvc
       .perform(
         get(fullURL + "/dungeons/" + initialDungeon.getIndex() + "/minigame-tasks/" + Integer.MAX_VALUE)
+          .cookie(cookie)
           .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isNotFound())
@@ -271,6 +293,7 @@ class MinigameTaskControllerTest {
     final MvcResult result = mvc
       .perform(
         put(fullURL + "/minigame-tasks/" + initialTask1.getIndex())
+          .cookie(cookie)
           .content(bodyValue)
           .contentType(MediaType.APPLICATION_JSON)
       )
@@ -303,6 +326,7 @@ class MinigameTaskControllerTest {
     final MvcResult result = mvc
       .perform(
         put(fullURL + "/dungeons/" + initialDungeon.getIndex() + "/minigame-tasks/" + initialTask3.getIndex())
+          .cookie(cookie)
           .content(bodyValue)
           .contentType(MediaType.APPLICATION_JSON)
       )

--- a/src/test/java/de/unistuttgart/overworldbackend/NPCControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/NPCControllerTest.java
@@ -2,10 +2,13 @@ package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.*;
 import de.unistuttgart.overworldbackend.data.mapper.DungeonMapper;
 import de.unistuttgart.overworldbackend.data.mapper.NPCMapper;
@@ -15,11 +18,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -51,6 +56,11 @@ class NPCControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -158,6 +168,9 @@ class NPCControllerTest {
       );
 
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
@@ -166,7 +179,9 @@ class NPCControllerTest {
     npcDTO.setText(Arrays.asList("Hey ho"));
     final String bodyValue = objectMapper.writeValueAsString(npcDTO);
     mvc
-      .perform(put(fullURL + "/" + Integer.MAX_VALUE).content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        put(fullURL + "/" + Integer.MAX_VALUE).cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound())
       .andReturn();
   }
@@ -182,7 +197,12 @@ class NPCControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(updateNPCDTO);
 
     final MvcResult result = mvc
-      .perform(put(fullURL + "/" + initialNPCDTO.getIndex()).content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        put(fullURL + "/" + initialNPCDTO.getIndex())
+          .content(bodyValue)
+          .cookie(cookie)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 
@@ -200,7 +220,12 @@ class NPCControllerTest {
     npcDTO.setText(Arrays.asList("Hey ho"));
     final String bodyValue = objectMapper.writeValueAsString(npcDTO);
     mvc
-      .perform(put(fullDungeonURL + "/" + Integer.MAX_VALUE).content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        put(fullDungeonURL + "/" + Integer.MAX_VALUE)
+          .cookie(cookie)
+          .content(bodyValue)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound())
       .andReturn();
   }
@@ -216,6 +241,7 @@ class NPCControllerTest {
     final MvcResult result = mvc
       .perform(
         put(fullDungeonURL + "/" + initialDungeonNPCDTO.getIndex())
+          .cookie(cookie)
           .content(bodyValue)
           .contentType(MediaType.APPLICATION_JSON)
       )

--- a/src/test/java/de/unistuttgart/overworldbackend/NPCInputControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/NPCInputControllerTest.java
@@ -1,11 +1,14 @@
 package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.*;
 import de.unistuttgart.overworldbackend.data.mapper.CourseMapper;
 import de.unistuttgart.overworldbackend.data.mapper.NPCMapper;
@@ -16,12 +19,14 @@ import de.unistuttgart.overworldbackend.repositories.PlayerNPCStatisticRepositor
 import de.unistuttgart.overworldbackend.repositories.PlayerStatisticRepository;
 import de.unistuttgart.overworldbackend.service.PlayerNPCStatisticService;
 import java.util.*;
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -53,6 +58,11 @@ class NPCInputControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -151,6 +161,9 @@ class NPCInputControllerTest {
     fullURL = "/internal";
     npcURL = String.format("/courses/%d/worlds/%d/npcs", initialCourse.getId(), initialWorld.getIndex());
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
@@ -163,7 +176,9 @@ class NPCInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerNPCStatisticData);
 
     final MvcResult result = mvc
-      .perform(post(fullURL + "/submit-npc-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-npc-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 
@@ -197,7 +212,9 @@ class NPCInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerNPCStatisticData);
 
     mvc
-      .perform(post(fullURL + "/submit-npc-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-npc-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound());
   }
 
@@ -210,7 +227,9 @@ class NPCInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerNPCStatisticData);
 
     mvc
-      .perform(post(fullURL + "/submit-npc-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-npc-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isNotFound());
   }
 
@@ -224,7 +243,9 @@ class NPCInputControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(playerNPCStatisticData);
 
     final MvcResult result = mvc
-      .perform(post(fullURL + "/submit-npc-pass").content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        post(fullURL + "/submit-npc-pass").cookie(cookie).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 
@@ -241,7 +262,10 @@ class NPCInputControllerTest {
 
     final MvcResult resultNPC = mvc
       .perform(
-        put(npcURL + "/" + initialNpcDTO.getIndex()).content(bodyValueNPC).contentType(MediaType.APPLICATION_JSON)
+        put(npcURL + "/" + initialNpcDTO.getIndex())
+          .cookie(cookie)
+          .content(bodyValueNPC)
+          .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isOk())
       .andReturn();

--- a/src/test/java/de/unistuttgart/overworldbackend/PlayerNPCStatisticControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/PlayerNPCStatisticControllerTest.java
@@ -2,10 +2,13 @@ package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.*;
 import de.unistuttgart.overworldbackend.data.mapper.CourseMapper;
 import de.unistuttgart.overworldbackend.data.mapper.NPCMapper;
@@ -14,12 +17,14 @@ import de.unistuttgart.overworldbackend.repositories.CourseRepository;
 import de.unistuttgart.overworldbackend.repositories.PlayerStatisticRepository;
 import de.unistuttgart.overworldbackend.service.PlayerNPCStatisticService;
 import java.util.*;
+import javax.servlet.http.Cookie;
 import javax.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -50,6 +55,11 @@ class PlayerNPCStatisticControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -150,6 +160,9 @@ class PlayerNPCStatisticControllerTest {
       );
 
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
@@ -159,7 +172,7 @@ class PlayerNPCStatisticControllerTest {
     );
 
     final MvcResult result = mvc
-      .perform(get(fullURL).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 
@@ -176,7 +189,7 @@ class PlayerNPCStatisticControllerTest {
     );
 
     final MvcResult result = mvc
-      .perform(get(fullURL + "/" + statistic.getId()).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/" + statistic.getId()).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 
@@ -197,7 +210,7 @@ class PlayerNPCStatisticControllerTest {
     );
 
     final MvcResult result = mvc
-      .perform(get(fullURL + "/" + UUID.randomUUID()).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/" + UUID.randomUUID()).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isNotFound())
       .andReturn();
   }

--- a/src/test/java/de/unistuttgart/overworldbackend/PlayerStatisticControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/PlayerStatisticControllerTest.java
@@ -155,7 +155,7 @@ class PlayerStatisticControllerTest {
     objectMapper = new ObjectMapper();
 
     doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
-    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn(initialPlayerStatistic.getUserId());
   }
 
   @Test
@@ -172,6 +172,26 @@ class PlayerStatisticControllerTest {
     final PlayerStatisticDTO playerStatisticDTOResult = objectMapper.readValue(
       result.getResponse().getContentAsString(),
       PlayerStatisticDTO.class
+    );
+
+    assertEquals(initialPlayerStatisticDTO, playerStatisticDTOResult);
+    assertEquals(initialPlayerStatisticDTO.getId(), playerStatisticDTOResult.getId());
+  }
+
+  @Test
+  void getOwnPlayerStatistic() throws Exception {
+    final MvcResult result = mvc
+            .perform(
+                    get(fullURL)
+                            .cookie(cookie)
+                            .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk())
+            .andReturn();
+
+    final PlayerStatisticDTO playerStatisticDTOResult = objectMapper.readValue(
+            result.getResponse().getContentAsString(),
+            PlayerStatisticDTO.class
     );
 
     assertEquals(initialPlayerStatisticDTO, playerStatisticDTOResult);

--- a/src/test/java/de/unistuttgart/overworldbackend/WorldControllerTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/WorldControllerTest.java
@@ -1,11 +1,14 @@
 package de.unistuttgart.overworldbackend;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.unistuttgart.gamifyit.authentificationvalidator.JWTValidatorService;
 import de.unistuttgart.overworldbackend.data.Course;
 import de.unistuttgart.overworldbackend.data.World;
 import de.unistuttgart.overworldbackend.data.WorldDTO;
@@ -13,11 +16,13 @@ import de.unistuttgart.overworldbackend.data.mapper.WorldMapper;
 import de.unistuttgart.overworldbackend.repositories.CourseRepository;
 import java.util.Arrays;
 import java.util.Set;
+import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -49,6 +54,11 @@ class WorldControllerTest {
 
   @Autowired
   private MockMvc mvc;
+
+  @MockBean
+  JWTValidatorService jwtValidatorService;
+
+  final Cookie cookie = new Cookie("access_token", "testToken");
 
   @Autowired
   private CourseRepository courseRepository;
@@ -93,12 +103,15 @@ class WorldControllerTest {
     fullURL = String.format("/courses/%d/worlds", initialCourse.getId());
 
     objectMapper = new ObjectMapper();
+
+    doNothing().when(jwtValidatorService).validateTokenOrThrow("testToken");
+    when(jwtValidatorService.extractUserId("testToken")).thenReturn("testUser");
   }
 
   @Test
   void getWorldsFromCourse() throws Exception {
     final MvcResult result = mvc
-      .perform(get(fullURL).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 
@@ -118,7 +131,7 @@ class WorldControllerTest {
   @Test
   void getWorldFromCourse() throws Exception {
     final MvcResult result = mvc
-      .perform(get(fullURL + "/" + initialWorldDTO.getIndex()).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/" + initialWorldDTO.getIndex()).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isOk())
       .andReturn();
 
@@ -131,7 +144,7 @@ class WorldControllerTest {
   @Test
   void getWorldFromCourse_DoesNotExist_ThrowsNotFound() throws Exception {
     mvc
-      .perform(get(fullURL + "/" + Integer.MAX_VALUE).contentType(MediaType.APPLICATION_JSON))
+      .perform(get(fullURL + "/" + Integer.MAX_VALUE).cookie(cookie).contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isNotFound())
       .andReturn();
   }
@@ -147,7 +160,10 @@ class WorldControllerTest {
 
     final MvcResult result = mvc
       .perform(
-        put(fullURL + "/" + initialWorldDTO.getIndex()).content(bodyValue).contentType(MediaType.APPLICATION_JSON)
+        put(fullURL + "/" + initialWorldDTO.getIndex())
+          .cookie(cookie)
+          .content(bodyValue)
+          .contentType(MediaType.APPLICATION_JSON)
       )
       .andExpect(status().isOk())
       .andReturn();
@@ -180,7 +196,12 @@ class WorldControllerTest {
     final String bodyValue = objectMapper.writeValueAsString(updatedWorldDTO);
 
     final MvcResult result = mvc
-      .perform(put(fullURL + "/" + initialWorld.getIndex()).content(bodyValue).contentType(MediaType.APPLICATION_JSON))
+      .perform(
+        put(fullURL + "/" + initialWorld.getIndex())
+          .cookie(cookie)
+          .content(bodyValue)
+          .contentType(MediaType.APPLICATION_JSON)
+      )
       .andExpect(status().isOk())
       .andReturn();
 


### PR DESCRIPTION
Part of Gamify-IT/issues#286

Points this PR closes:
- [x] player ID is no longer needed in URL to fetch player statistic
- [x] overworld backend authenticates lecturers on needed routes
- [x] api validates access token