### PR TITLE
changed path name for get request

### DIFF
--- a/src/main/java/de/unistuttgart/overworldbackend/controller/AreaMapController.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/controller/AreaMapController.java
@@ -17,7 +17,7 @@ import static de.unistuttgart.overworldbackend.data.Roles.LECTURER_ROLE;
 @Tag(name = "AreaMap", description = "Get and update area maps from a course")
 @RestController
 @Slf4j
-@RequestMapping("/courses/{courseId}/areaMaps")
+@RequestMapping("/courses/{courseId}/area")
 public class AreaMapController {
     @Autowired
     JWTValidatorService jwtValidatorService;

--- a/src/test/java/de/unistuttgart/overworldbackend/AreaMapTest.java
+++ b/src/test/java/de/unistuttgart/overworldbackend/AreaMapTest.java
@@ -120,7 +120,7 @@ public class AreaMapTest {
         assertNotNull(initialWorld.getId());
         assertNotNull(initialWorldDTO.getId());
 
-        fullURL = String.format("/courses/%d/areaMaps", initialCourse.getId());
+        fullURL = String.format("/courses/%d/area", initialCourse.getId());
 
         objectMapper = new ObjectMapper();
 


### PR DESCRIPTION
The path for the get request was changed so the Overworld frontend can load everything correctly and without errors.
Note: Currently, only world 1 will be loaded