### PR TITLE
Fix dungeon unlock order

### DIFF
--- a/src/main/java/de/unistuttgart/overworldbackend/service/PlayerStatisticService.java
+++ b/src/main/java/de/unistuttgart/overworldbackend/service/PlayerStatisticService.java
@@ -276,8 +276,8 @@ public class PlayerStatisticService {
                 currentWorld
                     .getDungeons()
                     .parallelStream()
-                    .min(Comparator.comparingInt(Area::getIndex))
                     .filter(Dungeon::isConfigured)
+                    .min(Comparator.comparingInt(Area::getIndex))
                     .ifPresentOrElse(
                         playerStatistic::addUnlockedArea,
                         () ->
@@ -293,8 +293,8 @@ public class PlayerStatisticService {
                     .getDungeons()
                     .parallelStream()
                     .filter(dungeon -> dungeon.getIndex() > currentDungeon.getIndex())
-                    .min(Comparator.comparingInt(Dungeon::getIndex))
                     .filter(Dungeon::isConfigured)
+                    .min(Comparator.comparingInt(Dungeon::getIndex))
                     .ifPresentOrElse(
                         playerStatistic::addUnlockedArea,
                         () ->


### PR DESCRIPTION
Changed the order in which the next world/dungeon to be unlocked is calculated to fix an error causing it to skip activated dungeons